### PR TITLE
Fixed Math Blaster's Mutt Textures

### DIFF
--- a/src/Controllers/Common/ContentController.cs
+++ b/src/Controllers/Common/ContentController.cs
@@ -596,7 +596,7 @@ public class ContentController : Controller {
 
     [HttpPost]
     [Produces("application/xml")]
-    [Route("ContentWebService.asmx/SetRaisedPet")] // used by World Of Jumpstart
+    [Route("ContentWebService.asmx/SetRaisedPet")] // used by World Of Jumpstart and Math Blaster
     [VikingSession]
     public IActionResult SetRaisedPetv1(Viking viking, [FromForm] string raisedPetData) {
         RaisedPetData petData = XmlUtil.DeserializeXml<RaisedPetData>(raisedPetData);
@@ -605,6 +605,17 @@ public class ContentController : Controller {
         Dragon? dragon = viking.Dragons.FirstOrDefault(e => e.Id == petData.RaisedPetID);
         if (dragon is null) {
             return Ok(false);
+        }
+
+        if (petData.Texture.StartsWith("RS_SHARED/Larva.unity3d/LarvaTex") && petData.GrowthState.GrowthStateID>4) {
+            petData.Texture = "RS_SHARED/" + petData.PetTypeID switch {
+                 5 => "EyeClops.unity3d/EyeClopsBrainRedTex",           // EyeClops
+                 6 => "RodeoLizard.unity3d/BlueLizardTex",              // RodeoLizard
+                 7 => "MonsterAlien01.unity3d/BlasterMythieGreenTex",   // MonsterAlien01
+                11 => "SpaceGriffin.unity3d/SpaceGriffinNormalBlueTex", // SpaceGriffin
+                10 => "Tweeter.unity3d/TweeterMuttNormalPurple",        // Tweeter
+                 _ => "null" // Anything with any other ID shouldn't exist.
+            };
         }
 
         dragon.RaisedPetData = XmlUtil.SerializeXml(UpdateDragon(dragon, petData));


### PR DESCRIPTION
The pet data saving code will now set to appropriate mutt texture if pet is using a larva texture and is older than HATCHING.
This fixes the issue that mutts were using their old larva's texture instead of the mutt's default texture.
Any existing mutts using the wrong texture will have it changed when the pet is *saved* (not when loaded). For users to see the fixed texture they would need to restart the game after the affected mutt(s)' data changed in any way (or otherwise saved to the server).

This is also up in the air but it may have inadvertently fixed the Mutt Pod Failing to Load issue as well.