### PR TITLE
Fix Mutt Textures not immediately Updating

### DIFF
--- a/src/Controllers/Common/ContentController.cs
+++ b/src/Controllers/Common/ContentController.cs
@@ -636,17 +636,6 @@ public class ContentController : Controller {
             return Ok(false);
         }
 
-        if (petData.Texture != null && petData.Texture.StartsWith("RS_SHARED/Larva.unity3d/LarvaTex") && petData.GrowthState.GrowthStateID>4) {
-            petData.Texture = "RS_SHARED/" + petData.PetTypeID switch {
-                 5 => "EyeClops.unity3d/EyeClopsBrainRedTex",           // EyeClops
-                 6 => "RodeoLizard.unity3d/BlueLizardTex",              // RodeoLizard
-                 7 => "MonsterAlien01.unity3d/BlasterMythieGreenTex",   // MonsterAlien01
-                11 => "SpaceGriffin.unity3d/SpaceGriffinNormalBlueTex", // SpaceGriffin
-                10 => "Tweeter.unity3d/TweeterMuttNormalPurple",        // Tweeter
-                 _ => "null" // Anything with any other ID shouldn't exist.
-            };
-        }
-
         dragon.RaisedPetData = XmlUtil.SerializeXml(UpdateDragon(dragon, petData));
         ctx.Update(dragon);
         ctx.SaveChanges();
@@ -2337,6 +2326,18 @@ public class ContentController : Controller {
         data.RaisedPetID = dragon.Id;
         data.EntityID = dragon.EntityId;
         data.IsSelected = (selectedDragonId == dragon.Id);
+
+        if (data.Texture != null && data.Texture.StartsWith("RS_SHARED/Larva.unity3d/LarvaTex") && data.GrowthState.GrowthStateID > 4) {
+            data.Texture = "RS_SHARED/" + data.PetTypeID switch {
+                5 => "EyeClops.unity3d/EyeClopsBrainRedTex",           // EyeClops
+                6 => "RodeoLizard.unity3d/BlueLizardTex",              // RodeoLizard
+                7 => "MonsterAlien01.unity3d/BlasterMythieGreenTex",   // MonsterAlien01
+                11 => "SpaceGriffin.unity3d/SpaceGriffinNormalBlueTex", // SpaceGriffin
+                10 => "Tweeter.unity3d/TweeterMuttNormalPurple",        // Tweeter
+                _ => "null" // Anything with any other ID shouldn't exist.
+            };
+        }
+
         return data;
     }
 

--- a/src/Controllers/Common/ContentController.cs
+++ b/src/Controllers/Common/ContentController.cs
@@ -1569,6 +1569,14 @@ public class ContentController : Controller {
 
             if (party.Location == "MyNeighborhood") userParty.DisplayName = $"{userParty.UserName}'s Block Party";
             if (party.Location == "MyVIPRoomInt") userParty.DisplayName = $"{userParty.UserName}'s VIP Party";
+            if (party.Location == "MyPodInt") {
+                // Only way to do this without adding another column to the table.
+                if (party.AssetBundle == "RS_DATA/PfMyPodBirthdayParty.unity3d/PfMyPodBirthdayParty") {
+                    userParty.DisplayName = $"{userParty.UserName}'s Pod Birthday Party";
+                } else {
+                    userParty.DisplayName = $"{userParty.UserName}'s Pod Party";
+                }
+            }
 
             userParties.Add(userParty);
         }
@@ -1624,7 +1632,7 @@ public class ContentController : Controller {
     [Produces("application/xml")]
     [Route("ContentWebService.asmx/PurchaseParty")] // used by World Of Jumpstart
     [VikingSession]
-    public IActionResult PurchaseParty(Viking viking, [FromForm] int itemId)
+    public IActionResult PurchaseParty(Viking viking, [FromForm] int itemId, [FromForm] string apiKey)
     {
         ItemData itemData = itemService.GetItem(itemId);
 
@@ -1640,14 +1648,25 @@ public class ContentController : Controller {
             return Ok(null);
         }
 
+        uint gameVersion = ClientVersion.GetVersion(apiKey);
         if (partyType == "Default") {
-            party.Location = "MyNeighborhood";
-            party.LocationIconAsset = "RS_DATA/PfUiPartiesList.unity3d/IcoPartyLocationMyNeighborhood";
-            party.AssetBundle = "RS_DATA/PfMyNeighborhoodParty.unity3d/PfMyNeighborhoodParty";
+            if (gameVersion == ClientVersion.MB) {
+                party.Location = "MyPodInt";
+                party.LocationIconAsset = "RS_DATA/PfUiPartiesListMB.unity3d/IcoMbPartyDefault";
+                party.AssetBundle = "RS_DATA/PfMyPodParty.unity3d/PfMyPodParty";
+            } else {
+                party.Location = "MyNeighborhood";
+                party.LocationIconAsset = "RS_DATA/PfUiPartiesList.unity3d/IcoPartyLocationMyNeighborhood";
+                party.AssetBundle = "RS_DATA/PfMyNeighborhoodParty.unity3d/PfMyNeighborhoodParty";
+            }
         } else if (partyType == "VIPRoom") {
             party.Location = "MyVIPRoomInt";
             party.LocationIconAsset = "RS_DATA/PfUiPartiesList.unity3d/IcoPartyDefault";
             party.AssetBundle = "RS_DATA/PfMyVIPRoomIntPartyGroup.unity3d/PfMyVIPRoomIntPartyGroup";
+        } else if (partyType == "Birthday") {
+            party.Location = "MyPodInt";
+            party.LocationIconAsset = "RS_DATA/PfUiPartiesListMB.unity3d/IcoMbPartyBirthday";
+            party.AssetBundle = "RS_DATA/PfMyPodBirthdayParty.unity3d/PfMyPodBirthdayParty";
         } else {
             Console.WriteLine($"Unsupported partyType = {partyType}");
             return Ok(null);

--- a/src/Controllers/Common/ContentController.cs
+++ b/src/Controllers/Common/ContentController.cs
@@ -639,7 +639,19 @@ public class ContentController : Controller {
             return Ok(false);
         }
 
-        dragon.RaisedPetData = XmlUtil.SerializeXml(UpdateDragon(dragon, petData));
+        petData = UpdateDragon(dragon, petData);
+        if (petData.Texture != null && petData.Texture.StartsWith("RS_SHARED/Larva.unity3d/LarvaTex") && data.GrowthState.GrowthStateID > 4) {
+            petData.Texture = "RS_SHARED/" + petData.PetTypeID switch {
+                5 => "EyeClops.unity3d/EyeClopsBrainRedTex",           // EyeClops
+                6 => "RodeoLizard.unity3d/BlueLizardTex",              // RodeoLizard
+                7 => "MonsterAlien01.unity3d/BlasterMythieGreenTex",   // MonsterAlien01
+                11 => "SpaceGriffin.unity3d/SpaceGriffinNormalBlueTex", // SpaceGriffin
+                10 => "Tweeter.unity3d/TweeterMuttNormalPurple",        // Tweeter
+                _ => "null" // Anything with any other ID shouldn't exist.
+            };
+        }
+        dragon.RaisedPetData = XmlUtil.SerializeXml(petData);
+
         ctx.Update(dragon);
         ctx.SaveChanges();
 
@@ -2329,18 +2341,6 @@ public class ContentController : Controller {
         data.RaisedPetID = dragon.Id;
         data.EntityID = dragon.EntityId;
         data.IsSelected = (selectedDragonId == dragon.Id);
-
-        if (data.Texture != null && data.Texture.StartsWith("RS_SHARED/Larva.unity3d/LarvaTex") && data.GrowthState.GrowthStateID > 4) {
-            data.Texture = "RS_SHARED/" + data.PetTypeID switch {
-                5 => "EyeClops.unity3d/EyeClopsBrainRedTex",           // EyeClops
-                6 => "RodeoLizard.unity3d/BlueLizardTex",              // RodeoLizard
-                7 => "MonsterAlien01.unity3d/BlasterMythieGreenTex",   // MonsterAlien01
-                11 => "SpaceGriffin.unity3d/SpaceGriffinNormalBlueTex", // SpaceGriffin
-                10 => "Tweeter.unity3d/TweeterMuttNormalPurple",        // Tweeter
-                _ => "null" // Anything with any other ID shouldn't exist.
-            };
-        }
-
         return data;
     }
 

--- a/src/Controllers/Common/ContentController.cs
+++ b/src/Controllers/Common/ContentController.cs
@@ -640,7 +640,7 @@ public class ContentController : Controller {
         }
 
         petData = UpdateDragon(dragon, petData);
-        if (petData.Texture != null && petData.Texture.StartsWith("RS_SHARED/Larva.unity3d/LarvaTex") && data.GrowthState.GrowthStateID > 4) {
+        if (petData.Texture != null && petData.Texture.StartsWith("RS_SHARED/Larva.unity3d/LarvaTex") && petData.GrowthState.GrowthStateID > 4) {
             petData.Texture = "RS_SHARED/" + petData.PetTypeID switch {
                 5 => "EyeClops.unity3d/EyeClopsBrainRedTex",           // EyeClops
                 6 => "RodeoLizard.unity3d/BlueLizardTex",              // RodeoLizard


### PR DESCRIPTION
Moved the updated texture from the setter method to the general getter method.
Doing this will bridge the gap in the event the player doesn't interact with the mutt before quitting the game.
Therefore the new texture data is sent immediately and the client can save the proper texture itself.